### PR TITLE
Add support for Mach-O indianness

### DIFF
--- a/Nitrox.Discovery/Extensions/StringExtensions.cs
+++ b/Nitrox.Discovery/Extensions/StringExtensions.cs
@@ -31,16 +31,17 @@ internal static class StringExtensions
 
     public static bool IsExecutableFile(this string pathToFile)
     {
+        BinaryReader fs = null;
         try
         {
-            using BinaryReader fs = new(File.OpenRead(pathToFile));
-
+            fs = new(File.OpenRead(pathToFile));
             byte[] header = fs.ReadBytes(4);
 
-            if (IsOSPlatform(OSPlatform.Windows))
+            // Check for MZ even on non-Windows platforms because they could be used for Proton/Wine emulation.
+            if (IsOSPlatform(OSPlatform.Windows) || Path.GetExtension(pathToFile).Equals(".exe", StringComparison.OrdinalIgnoreCase))
             {
                 // MZ (ASCII)
-                return header is [0x4D, 0x5A, ..] || Path.GetExtension(pathToFile).Equals(".exe", StringComparison.OrdinalIgnoreCase);
+                return header is [0x4D, 0x5A, ..];
             }
             else if (IsOSPlatform(OSPlatform.Linux))
             {
@@ -49,18 +50,39 @@ internal static class StringExtensions
             }
             else if (IsOSPlatform(OSPlatform.OSX))
             {
-                // Mach-O 32bit (big-endian and little-endian)
-                return header is [0xFE, 0xED, 0xFA, 0xCE] or [0xCE, 0xFA, 0xED, 0xFE]
-                // Mach-O 64bit (big-endian and little-endian)
-                              or [0xFE, 0xED, 0xFA, 0xCF] or [0xCF, 0xFA, 0xED, 0xFE]
-                // Fat Mach-O 32bit (big-endian and little-endian)
-                              or [0xCA, 0xFE, 0xBA, 0xBE] or [0xBE, 0xBA, 0xFE, 0xCA]
-                // Fat Mach-O 64bit (big-endian and little-endian)
-                              or [0xCA, 0xFE, 0xBA, 0xBF] or [0xBF, 0xBA, 0xFE, 0xCA];
+                if (BitConverter.IsLittleEndian)
+                {
+                    return header switch
+                    {
+                        // Mach-O 32bit
+                        [0xCE, 0xFA, 0xED, 0xFE] => true,
+                        // Mach-O 64bit
+                        [0xCF, 0xFA, 0xED, 0xFE] => true,
+                        // Fat Mach-O 32bit
+                        [0xBE, 0xBA, 0xFE, 0xCA] => true,
+                        // Fat Mach-O 64bit
+                        [0xBF, 0xBA, 0xFE, 0xCA] => true,
+                        _ => false
+                    };
+                }
+                else
+                {
+                    return header switch
+                    {
+                        // Mach-O 32bit
+                        [0xFE, 0xED, 0xFA, 0xCE] => true,
+                        // Mach-O 64bit
+                        [0xFE, 0xED, 0xFA, 0xCF] => true,
+                        // Fat Mach-O 32bit
+                        [0xCA, 0xFE, 0xBA, 0xBE] => true,
+                        // Fat Mach-O 64bit
+                        [0xCA, 0xFE, 0xBA, 0xBF] => true,
+                        _ => false
+                    };
+                }
             }
 
-            // Fallback ?
-            return Path.GetExtension(pathToFile).Equals(".exe", StringComparison.OrdinalIgnoreCase);
+            return false;
         }
         catch (UnauthorizedAccessException)
         {
@@ -69,6 +91,10 @@ internal static class StringExtensions
         catch (IOException)
         {
             return false;
+        }
+        finally
+        {
+            fs?.Dispose();
         }
     }
 

--- a/Nitrox.Discovery/Extensions/StringExtensions.cs
+++ b/Nitrox.Discovery/Extensions/StringExtensions.cs
@@ -34,16 +34,33 @@ internal static class StringExtensions
         try
         {
             using BinaryReader fs = new(File.OpenRead(pathToFile));
-            return fs.ReadBytes(4) switch
+
+            byte[] header = fs.ReadBytes(4);
+
+            if (IsOSPlatform(OSPlatform.Windows))
             {
                 // MZ (ASCII)
-                [0x4D, 0x5A, ..] when IsOSPlatform(OSPlatform.Windows) || Path.GetExtension(pathToFile).Equals(".exe", StringComparison.OrdinalIgnoreCase) => true,
+                return header is [0x4D, 0x5A, ..];
+            }
+            else if (IsOSPlatform(OSPlatform.Linux))
+            {
                 // 7F + ELF (ASCII)
-                [0x7F, 0x45, 0x4C, 0x46] when IsOSPlatform(OSPlatform.Linux) => true,
-                // Either 32bit or 64bit program respectively
-                [0xFE, 0xED, 0xFA, 0xCE] or [0xFE, 0xED, 0xFA, 0xCF] when IsOSPlatform(OSPlatform.OSX) => true,
-                _ => false
-            };
+                return header is [0x7F, 0x45, 0x4C, 0x46];
+            }
+            else if (IsOSPlatform(OSPlatform.OSX))
+            {
+                // Mach-O 32bit (big-endian and little-endian)
+                return header is [0xFE, 0xED, 0xFA, 0xCE] or [0xCE, 0xFA, 0xED, 0xFE]
+                // Mach-O 64bit (big-endian and little-endian)
+                              or [0xFE, 0xED, 0xFA, 0xCF] or [0xCF, 0xFA, 0xED, 0xFE]
+                // Fat Mach-O 32bit (big-endian and little-endian)
+                              or [0xCA, 0xFE, 0xBA, 0xBE] or [0xBE, 0xBA, 0xFE, 0xCA]
+                // Fat Mach-O 64bit (big-endian and little-endian)
+                              or [0xCA, 0xFE, 0xBA, 0xBF] or [0xBF, 0xBA, 0xFE, 0xCA];
+            }
+
+            // Fallback ?
+            return Path.GetExtension(pathToFile).Equals(".exe", StringComparison.OrdinalIgnoreCase);
         }
         catch (UnauthorizedAccessException)
         {

--- a/Nitrox.Discovery/Extensions/StringExtensions.cs
+++ b/Nitrox.Discovery/Extensions/StringExtensions.cs
@@ -40,7 +40,7 @@ internal static class StringExtensions
             if (IsOSPlatform(OSPlatform.Windows))
             {
                 // MZ (ASCII)
-                return header is [0x4D, 0x5A, ..];
+                return header is [0x4D, 0x5A, ..] || Path.GetExtension(pathToFile).Equals(".exe", StringComparison.OrdinalIgnoreCase);
             }
             else if (IsOSPlatform(OSPlatform.Linux))
             {

--- a/Nitrox.Discovery/Extensions/StringExtensions.cs
+++ b/Nitrox.Discovery/Extensions/StringExtensions.cs
@@ -31,58 +31,11 @@ internal static class StringExtensions
 
     public static bool IsExecutableFile(this string pathToFile)
     {
-        BinaryReader fs = null;
+        byte[] header;
         try
         {
-            fs = new(File.OpenRead(pathToFile));
-            byte[] header = fs.ReadBytes(4);
-
-            // Check for MZ even on non-Windows platforms because they could be used for Proton/Wine emulation.
-            if (IsOSPlatform(OSPlatform.Windows) || Path.GetExtension(pathToFile).Equals(".exe", StringComparison.OrdinalIgnoreCase))
-            {
-                // MZ (ASCII)
-                return header is [0x4D, 0x5A, ..];
-            }
-            else if (IsOSPlatform(OSPlatform.Linux))
-            {
-                // 7F + ELF (ASCII)
-                return header is [0x7F, 0x45, 0x4C, 0x46];
-            }
-            else if (IsOSPlatform(OSPlatform.OSX))
-            {
-                if (BitConverter.IsLittleEndian)
-                {
-                    return header switch
-                    {
-                        // Mach-O 32bit
-                        [0xCE, 0xFA, 0xED, 0xFE] => true,
-                        // Mach-O 64bit
-                        [0xCF, 0xFA, 0xED, 0xFE] => true,
-                        // Fat Mach-O 32bit
-                        [0xBE, 0xBA, 0xFE, 0xCA] => true,
-                        // Fat Mach-O 64bit
-                        [0xBF, 0xBA, 0xFE, 0xCA] => true,
-                        _ => false
-                    };
-                }
-                else
-                {
-                    return header switch
-                    {
-                        // Mach-O 32bit
-                        [0xFE, 0xED, 0xFA, 0xCE] => true,
-                        // Mach-O 64bit
-                        [0xFE, 0xED, 0xFA, 0xCF] => true,
-                        // Fat Mach-O 32bit
-                        [0xCA, 0xFE, 0xBA, 0xBE] => true,
-                        // Fat Mach-O 64bit
-                        [0xCA, 0xFE, 0xBA, 0xBF] => true,
-                        _ => false
-                    };
-                }
-            }
-
-            return false;
+            using BinaryReader fs = new(File.OpenRead(pathToFile));
+            header = fs.ReadBytes(4);
         }
         catch (UnauthorizedAccessException)
         {
@@ -92,10 +45,50 @@ internal static class StringExtensions
         {
             return false;
         }
-        finally
+
+        // Check for MZ even on non-Windows platforms because they could be used for Proton/Wine emulation.
+        if (IsOSPlatform(OSPlatform.Windows) || Path.GetExtension(pathToFile).Equals(".exe", StringComparison.OrdinalIgnoreCase))
         {
-            fs?.Dispose();
+            // MZ (ASCII)
+            return header is [0x4D, 0x5A, ..];
         }
+        if (IsOSPlatform(OSPlatform.Linux))
+        {
+            // 7F + ELF (ASCII)
+            return header is [0x7F, 0x45, 0x4C, 0x46];
+        }
+        if (IsOSPlatform(OSPlatform.OSX))
+        {
+            if (BitConverter.IsLittleEndian)
+            {
+                return header switch
+                {
+                    // Mach-O 32bit
+                    [0xCE, 0xFA, 0xED, 0xFE] => true,
+                    // Mach-O 64bit
+                    [0xCF, 0xFA, 0xED, 0xFE] => true,
+                    // Fat Mach-O 32bit
+                    [0xBE, 0xBA, 0xFE, 0xCA] => true,
+                    // Fat Mach-O 64bit
+                    [0xBF, 0xBA, 0xFE, 0xCA] => true,
+                    _ => false
+                };
+            }
+            return header switch
+            {
+                // Mach-O 32bit
+                [0xFE, 0xED, 0xFA, 0xCE] => true,
+                // Mach-O 64bit
+                [0xFE, 0xED, 0xFA, 0xCF] => true,
+                // Fat Mach-O 32bit
+                [0xCA, 0xFE, 0xBA, 0xBE] => true,
+                // Fat Mach-O 64bit
+                [0xCA, 0xFE, 0xBA, 0xBF] => true,
+                _ => false
+            };
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/TestProject/DiscoverGameTest.cs
+++ b/TestProject/DiscoverGameTest.cs
@@ -16,7 +16,7 @@ public class DiscoverGameTest
     public void Startup()
     {
         buildEngine = Substitute.For<IBuildEngine>();
-        errors = new();
+        errors = [];
         buildEngine.When(x => x.LogErrorEvent(Arg.Any<BuildErrorEventArgs>())).Do(info => errors.Add(info.Arg<BuildErrorEventArgs>()));
     }
 

--- a/TestProject/TestProject.csproj
+++ b/TestProject/TestProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
 


### PR DESCRIPTION
Context :
Discovered 
<img width="937" height="143" alt="Screenshot 2026-03-07 at 09 53 51" src="https://github.com/user-attachments/assets/45287fa3-1c74-47c9-86ed-fcecbcf342b4" />

This PR add supports for little endian Mach-O binaries, which helps discovery to identify executables

| Header      | Description             |
|-------------|-------------------------|
| FE ED FA CE | Mach-O 32 Big endian    |
| CE FA ED FE | Mach-O 32 Little endian |
| FE ED FA CF | Mach-O 64 Big endian    |
| CF FA ED FE | Mach-O 64 Little endian |

With that being said, there's also universal/fat mach-O files (CA FE BA BE) that acts like a bundle that can contain slices of binaries for different arch

EDIT: I added those
| Header      | Description             |
|-------------|-------------------------|
| CA FE BA BE | Fat Mach-O 32 Big endian    |
| BE BA FE CA | Fat Mach-O 32 Little endian |
| CA FE BA BF | Fat Mach-O 64 Big endian    |
| BF BA FE CA | Fat Mach-O 64 Little endian |